### PR TITLE
Fix Dockerfile permissions for Render

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,11 +38,11 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     --mount=type=bind,source=requirements.txt,target=requirements.txt \
     python -m pip install -r requirements.txt
 
+# Copy source code with runtime ownership to avoid permission issues.
+COPY --chown=appuser:appuser . .
+
 # Switch to the non-privileged user to run the application.
 USER appuser
-
-# Copy the source code into the container.
-COPY . .
 
 # Expose the port that the application listens on.
 EXPOSE 8000


### PR DESCRIPTION
Fixes deployment crash by ensuring files are owned by the runtime user in Docker images (COPY --chown). Also adds persistent project context (AGENTS.md, Cursor rules/skills) to improve dev workflow.